### PR TITLE
Remove approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,7 @@
 approvers:
+- tonytcampbell
+- madorn
+- jomkz
 
 reviewers:
 - acmenezes

--- a/OWNERS
+++ b/OWNERS
@@ -1,27 +1,5 @@
 approvers:
-- acmenezes
-- acornett21
-- bcrochet
-- dcurran90
-- dhoover103
-- itroyano
-- jfrancin
-- jomkz
-- jsm84
-- komish
-- madorn
-- makon57
-- mgoerens
-- mrhillsman
-- OchiengEd
-- rocrisp
-- samira-barouti
-- skattoju
-- spabba17
-- tonytcampbell
-- trgeiger
-- yashoza19
-- yuriolisa
+
 reviewers:
 - acmenezes
 - acornett21


### PR DESCRIPTION
It is reasonable for all org members at this time to be reviewers when using this template but not approvers.